### PR TITLE
Add support for Function definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Python
+__pycache__
+
 # non-dev env files
 production.env
 

--- a/frameview.webpack.common.ts
+++ b/frameview.webpack.common.ts
@@ -70,7 +70,7 @@ export default {
     new CopyWebpackPlugin({
       patterns: [
         {
-          from: path.resolve('node_modules', '@splootcode', 'runtime-python', 'static'),
+          from: path.resolve('node_modules', '@splootcode', 'runtime-python', 'python', 'executor.py'),
           to: 'runtime-python/static',
         },
       ],

--- a/packages/core/language/capture/runtime_capture.ts
+++ b/packages/core/language/capture/runtime_capture.ts
@@ -54,3 +54,8 @@ export interface StatementCapture {
   exceptionType?: string
   exceptionMessage?: string
 }
+
+export interface CapturePayload {
+  root: StatementCapture
+  detached: { [key: string]: StatementCapture[] }
+}

--- a/packages/core/language/node.ts
+++ b/packages/core/language/node.ts
@@ -83,6 +83,7 @@ export class SplootNode {
   recursivelyApplyRuntimeCapture(capture: StatementCapture): boolean {
     if (capture.type != this.type) {
       console.warn(`Capture type ${capture.type} does not match node type ${this.type}`)
+      return false
     }
     if (capture.type == 'EXCEPTION') {
       this.applyRuntimeError(capture)

--- a/packages/core/language/node_category_registry.ts
+++ b/packages/core/language/node_category_registry.ts
@@ -34,6 +34,8 @@ export enum NodeCategory {
   PythonExpression,
   PythonExpressionToken,
   PythonAssignableExpressionToken,
+  PythonFunctionName,
+  PythonFunctionArgumentDeclaration,
   PythonModuleIdentifier,
   PythonModuleAttribute,
 }

--- a/packages/core/language/type_loader.ts
+++ b/packages/core/language/type_loader.ts
@@ -41,6 +41,7 @@ import { PythonExpression } from './types/python/python_expression'
 import { PythonFile } from './types/python/python_file'
 import { PythonForLoop } from './types/python/python_for'
 import { PythonFromImport } from './types/python/python_from_import'
+import { PythonFunctionDeclaration } from './types/python/python_function'
 import { PythonIfStatement } from './types/python/python_if'
 import { PythonImport } from './types/python/python_import'
 import { PythonModuleIdentifier } from './types/python/python_module_identifier'
@@ -135,6 +136,7 @@ export function loadTypes() {
   PythonElifBlock.register()
   PythonWhileLoop.register()
   PythonForLoop.register()
+  PythonFunctionDeclaration.register()
   PythonExpression.register()
   PythonBinaryOperator.register()
   PythonCallVariable.register()

--- a/packages/core/language/types/python/declared_identifier.ts
+++ b/packages/core/language/types/python/declared_identifier.ts
@@ -51,6 +51,23 @@ export class ModuleAttributeGenerator implements SuggestionGenerator {
   }
 }
 
+export class FunctionNameGenerator implements SuggestionGenerator {
+  staticSuggestions(parent: ParentReference, index: number) {
+    return []
+  }
+
+  dynamicSuggestions(parent: ParentReference, index: number, textInput: string) {
+    let varName = sanitizeIdentifier(textInput)
+    if (varName.length === 0 || (varName[0] <= '9' && varName[0] >= '0')) {
+      varName = '_' + varName
+    }
+
+    const newVar = new PythonDeclaredIdentifier(null, varName)
+    const suggestedNode = new SuggestedNode(newVar, `identifier ${varName}`, 'new variable', true, 'new variable')
+    return [suggestedNode]
+  }
+}
+
 export class VariableDeclarationGenerator implements SuggestionGenerator {
   staticSuggestions(parent: ParentReference, index: number) {
     const scope = parent.node.getScope()
@@ -114,5 +131,11 @@ export class PythonDeclaredIdentifier extends SplootNode {
       new VariableDeclarationGenerator()
     )
     registerNodeCateogry(PYTHON_DECLARED_IDENTIFIER, NodeCategory.PythonModuleAttribute, new ModuleAttributeGenerator())
+    registerNodeCateogry(PYTHON_DECLARED_IDENTIFIER, NodeCategory.PythonFunctionName, new FunctionNameGenerator())
+    registerNodeCateogry(
+      PYTHON_DECLARED_IDENTIFIER,
+      NodeCategory.PythonFunctionArgumentDeclaration,
+      new FunctionNameGenerator()
+    )
   }
 }

--- a/packages/core/language/types/python/python_function.ts
+++ b/packages/core/language/types/python/python_function.ts
@@ -1,0 +1,101 @@
+import { ChildSetType } from '../../childset'
+import { FunctionDefinition } from '../../definitions/loader'
+import { HighlightColorCategory } from '../../../colors'
+import {
+  LayoutComponent,
+  LayoutComponentType,
+  NodeLayout,
+  SerializedNode,
+  TypeRegistration,
+  registerType,
+} from '../../type_registry'
+import { NodeCategory, SuggestionGenerator, registerNodeCateogry } from '../../node_category_registry'
+import { ParentReference, SplootNode } from '../../node'
+import { PythonDeclaredIdentifier } from './declared_identifier'
+import { PythonStatement } from './python_statement'
+import { SuggestedNode } from '../../suggested_node'
+
+export const PYTHON_FUNCTION_DECLARATION = 'PYTHON_FUNCTION_DECLARATION'
+
+class Generator implements SuggestionGenerator {
+  staticSuggestions(parent: ParentReference, index: number): SuggestedNode[] {
+    const sampleNode = new PythonFunctionDeclaration(null)
+    const suggestedNode = new SuggestedNode(sampleNode, 'function', 'function def', true, 'Define a new function')
+    return [suggestedNode]
+  }
+
+  dynamicSuggestions(parent: ParentReference, index: number, textInput: string): SuggestedNode[] {
+    return []
+  }
+}
+
+export class PythonFunctionDeclaration extends SplootNode {
+  constructor(parentReference: ParentReference) {
+    super(parentReference, PYTHON_FUNCTION_DECLARATION)
+    this.addChildSet('identifier', ChildSetType.Single, NodeCategory.PythonFunctionName)
+    this.addChildSet('params', ChildSetType.Many, NodeCategory.PythonFunctionArgumentDeclaration)
+    this.addChildSet('body', ChildSetType.Many, NodeCategory.PythonStatement)
+  }
+
+  getIdentifier() {
+    return this.getChildSet('identifier')
+  }
+
+  getParams() {
+    return this.getChildSet('params')
+  }
+
+  getBody() {
+    return this.getChildSet('body')
+  }
+
+  addSelfToScope() {
+    if (this.getIdentifier().getCount() === 0) {
+      // No identifier, we can't be added to the scope.
+      return
+    }
+    const identifier = (this.getIdentifier().getChild(0) as PythonDeclaredIdentifier).getName()
+    this.getScope(true).addFunction({
+      name: identifier,
+      deprecated: false,
+      documentation: 'Local function',
+      type: {
+        parameters: [],
+        returnType: { type: 'any' },
+      },
+    } as FunctionDefinition)
+  }
+
+  static deserializer(serializedNode: SerializedNode): PythonFunctionDeclaration {
+    const node = new PythonFunctionDeclaration(null)
+    node.deserializeChildSet('identifier', serializedNode)
+    node.deserializeChildSet('params', serializedNode)
+    node.deserializeChildSet('body', serializedNode)
+    return node
+  }
+
+  static register() {
+    const typeRegistration = new TypeRegistration()
+    typeRegistration.typeName = PYTHON_FUNCTION_DECLARATION
+    typeRegistration.deserializer = PythonFunctionDeclaration.deserializer
+    typeRegistration.hasScope = true
+    typeRegistration.properties = ['identifier']
+    typeRegistration.childSets = { params: NodeCategory.DeclaredIdentifier, body: NodeCategory.Statement }
+    typeRegistration.layout = new NodeLayout(HighlightColorCategory.FUNCTION_DEFINITION, [
+      new LayoutComponent(LayoutComponentType.KEYWORD, 'function'),
+      new LayoutComponent(LayoutComponentType.CHILD_SET_INLINE, 'identifier'),
+      new LayoutComponent(LayoutComponentType.CHILD_SET_ATTACH_RIGHT, 'params'),
+      new LayoutComponent(LayoutComponentType.CHILD_SET_BLOCK, 'body'),
+    ])
+    typeRegistration.pasteAdapters = {
+      PYTHON_STATEMENT: (node: SplootNode) => {
+        const statement = new PythonStatement(null)
+        statement.getStatement().addChild(node)
+        return statement
+      },
+    }
+
+    registerType(typeRegistration)
+    registerNodeCateogry(PYTHON_FUNCTION_DECLARATION, NodeCategory.PythonStatementContents, new Generator())
+  }
+}

--- a/packages/core/language/types/python/python_function.ts
+++ b/packages/core/language/types/python/python_function.ts
@@ -10,8 +10,8 @@ import {
   registerType,
 } from '../../type_registry'
 import { NodeCategory, SuggestionGenerator, registerNodeCateogry } from '../../node_category_registry'
+import { PYTHON_DECLARED_IDENTIFIER, PythonDeclaredIdentifier } from './declared_identifier'
 import { ParentReference, SplootNode } from '../../node'
-import { PythonDeclaredIdentifier } from './declared_identifier'
 import { PythonStatement } from './python_statement'
 import { SuggestedNode } from '../../suggested_node'
 
@@ -64,6 +64,19 @@ export class PythonFunctionDeclaration extends SplootNode {
         returnType: { type: 'any' },
       },
     } as FunctionDefinition)
+
+    const scope = this.getScope(false)
+    this.getParams().children.forEach((paramNode) => {
+      if (paramNode.type === PYTHON_DECLARED_IDENTIFIER) {
+        const identifier = paramNode as PythonDeclaredIdentifier
+        scope.addVariable({
+          name: identifier.getName(),
+          deprecated: false,
+          type: { type: 'any' },
+          documentation: 'Function parameter',
+        })
+      }
+    })
   }
 
   static deserializer(serializedNode: SerializedNode): PythonFunctionDeclaration {

--- a/packages/core/language/types/python/python_while.ts
+++ b/packages/core/language/types/python/python_while.ts
@@ -98,7 +98,7 @@ export class PythonWhileLoop extends SplootNode {
       const condition = frameData.condition[0]
       const conditionData = condition.data as SingleStatementData
 
-      if (condition.sideEffects.length > 0) {
+      if (condition.sideEffects && condition.sideEffects.length > 0) {
         const stdout = condition.sideEffects
           .filter((sideEffect) => sideEffect.type === 'stdout')
           .map((sideEffect) => sideEffect.value)

--- a/packages/editor/components/attached_child.tsx
+++ b/packages/editor/components/attached_child.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { observer } from 'mobx-react'
 
 import { EditorNodeBlock } from './node_block'
+import { NodeBlock } from '../layout/rendered_node'
 import { NodeSelection } from '../context/selection'
 import { RenderedChildSetBlock } from '../layout/rendered_childset_block'
 
@@ -19,57 +20,33 @@ export class AttachedChildRightExpressionView extends React.Component<AttachedCh
     const { isSelected, block } = this.props
     const topPos = block.y
 
-    const allowInsert = block.allowInsertCursor()
+    const bracketLeftPos = block.x + 16
+    const childWidth = block.width - 16 - 6
 
-    // Can only be one child (or zero) for attached childsets
-    const child = block.nodes.length > 0 ? block.nodes[0] : null
-    const selectionState = block.getChildSelectionState(0)
-    /*
-     A rx ry x-axis-rotation large-arc-flag sweep-flag x y
-     a rx ry x-axis-rotation large-arc-flag sweep-flag dx dy
-    */
-    const childWidth = child === null ? 0 : child.rowWidth
-
-    // TODO: This is going to break when we have a labeled childset with no contents, no child.
-    const bracketLeftPos = child === null ? block.x + 4 : child.x - 16
-    const labelClass = 'tree-label ' + (isSelected ? 'selected' : '')
-    const label = (
-      <text className={labelClass} x={block.x + 6} y={block.y + 12}>
-        {block.childSetRightAttachLabel}
-      </text>
-    )
     const connectorClass = 'tree-connector ' + (isSelected ? 'selected' : '')
-    if (allowInsert) {
-      return (
-        <React.Fragment>
-          <line className={connectorClass} x1={block.x + 1} y1={topPos + 16} x2={bracketLeftPos + 6} y2={topPos + 16} />
-          {label}
-          <path
-            className={connectorClass}
-            d={'M ' + (bracketLeftPos + 9) + ' ' + topPos + ' a 40 40 45 0 0 0 30'}
-            fill="transparent"
-          ></path>
-          <path
-            className={connectorClass}
-            d={'M ' + (bracketLeftPos + childWidth + 18) + ' ' + topPos + ' a 40 40 45 0 1 0 30'}
-            fill="transparent"
-          ></path>
-        </React.Fragment>
-      )
-    }
+
     return (
       <React.Fragment>
-        <line className={connectorClass} x1={block.x + 1} y1={topPos + 16} x2={bracketLeftPos + 6} y2={topPos + 16} />
-        {label}
+        {/* <rect x={block.x} y={block.y} width={block.width} height={block.height} fill="white" />
+        <rect x={bracketLeftPos} y={block.y} width={childWidth} height={block.height} fill="cyan" /> */}
+        <line className={connectorClass} x1={block.x + 1} y1={topPos + 16} x2={bracketLeftPos - 3} y2={topPos + 16} />
+        {/* {label} */}
         <path
           className={connectorClass}
-          d={'M ' + (bracketLeftPos + 9) + ' ' + topPos + ' a 40 40 45 0 0 0 30'}
+          d={'M ' + bracketLeftPos + ' ' + topPos + ' a 40 40 45 0 0 0 30'}
           fill="transparent"
         ></path>
-        <EditorNodeBlock block={child} selection={this.props.selection} selectionState={selectionState} />
+        {block.nodes.map((nodeBlock: NodeBlock, idx: number) => {
+          const selectionState = block.getChildSelectionState(idx)
+          return (
+            <React.Fragment key={idx}>
+              <EditorNodeBlock block={nodeBlock} selection={this.props.selection} selectionState={selectionState} />
+            </React.Fragment>
+          )
+        })}
         <path
           className={connectorClass}
-          d={'M ' + (bracketLeftPos + childWidth + 18) + ' ' + topPos + ' a 40 40 45 0 1 0 30'}
+          d={'M ' + (bracketLeftPos + childWidth) + ' ' + topPos + ' a 40 40 45 0 1 0 30'}
           fill="transparent"
         ></path>
       </React.Fragment>

--- a/packages/editor/components/cursor.tsx
+++ b/packages/editor/components/cursor.tsx
@@ -54,6 +54,7 @@ export class ActiveCursor extends React.Component<ActiveCursorProps> {
 
     switch (listBlock.componentType) {
       case LayoutComponentType.CHILD_SET_TOKEN_LIST:
+      case LayoutComponentType.CHILD_SET_ATTACH_RIGHT:
         return <line className="active-inline-cursor" x1={x - 2} y1={y + 2} x2={x - 2} y2={y + 28} />
       case LayoutComponentType.CHILD_SET_INLINE:
         return <line className="active-inline-cursor" x1={x + 2} y1={y + 2} x2={x + 2} y2={y + 28} />

--- a/packages/editor/components/insert_box.tsx
+++ b/packages/editor/components/insert_box.tsx
@@ -23,7 +23,7 @@ interface RenderedSuggestion extends SuggestedNode {
 
 function renderSuggestion(suggestedNode: SuggestedNode): RenderedSuggestion {
   const rendered = suggestedNode as RenderedSuggestion
-  rendered.nodeBlock = new NodeBlock(null, suggestedNode.node, null, 0, false)
+  rendered.nodeBlock = new NodeBlock(null, suggestedNode.node, null, 0)
   rendered.nodeBlock.calculateDimensions(0, 0, null)
   return rendered
 }

--- a/packages/editor/components/tray.tsx
+++ b/packages/editor/components/tray.tsx
@@ -129,7 +129,7 @@ function getTrayNodeSuggestions(rootNode: SplootNode): [NodeBlock[], number] {
   const renderedNodes = []
   let topPos = 10
   for (const node of nodes) {
-    const nodeBlock = new NodeBlock(null, node, null, 0, false)
+    const nodeBlock = new NodeBlock(null, node, null, 0)
     nodeBlock.calculateDimensions(16, topPos, null)
     topPos += nodeBlock.rowHeight + nodeBlock.indentedBlockHeight + 10
     renderedNodes.push(nodeBlock)

--- a/packages/editor/components/tree_list_block.tsx
+++ b/packages/editor/components/tree_list_block.tsx
@@ -107,7 +107,7 @@ export class TreeListBlockBracketsView extends React.Component<TreeListBlockView
                 className={connectorClass}
                 x1={leftPos + 8}
                 y1={topPos + 16}
-                x2={nodeBlock.x - 8}
+                x2={nodeBlock.x - 4}
                 y2={topPos + 16}
               />
             )
@@ -125,7 +125,7 @@ export class TreeListBlockBracketsView extends React.Component<TreeListBlockView
                   ' ' +
                   (nodeBlock.y + 16) +
                   ' H ' +
-                  (nodeBlock.x - 8)
+                  (nodeBlock.x - 4)
                 }
                 fill="transparent"
               />
@@ -137,7 +137,7 @@ export class TreeListBlockBracketsView extends React.Component<TreeListBlockView
               {label}
               <path
                 className={connectorClass}
-                d={'M ' + (nodeBlock.x - 6) + ' ' + nodeBlock.y + ' a 40 40 45 0 0 0 30'}
+                d={'M ' + nodeBlock.x + ' ' + nodeBlock.y + ' a 40 40 45 0 0 0 30'}
                 fill="transparent"
               ></path>
               <EditorNodeBlock block={nodeBlock} selection={this.props.selection} selectionState={selectionState} />

--- a/packages/editor/context/selection.ts
+++ b/packages/editor/context/selection.ts
@@ -430,7 +430,7 @@ export class NodeSelection {
   }
 
   startDrag(nodeBlock: NodeBlock, offsetX: number, offestY: number) {
-    const tempNodeBlock = new NodeBlock(null, nodeBlock.node, null, 0, false)
+    const tempNodeBlock = new NodeBlock(null, nodeBlock.node, null, 0)
     tempNodeBlock.calculateDimensions(0, 0, null)
     this.dragState = {
       node: tempNodeBlock,

--- a/packages/editor/layout/rendered_childset_block.ts
+++ b/packages/editor/layout/rendered_childset_block.ts
@@ -82,8 +82,7 @@ export class RenderedChildSetBlock implements ChildSetObserver {
     this.width = 0
     this.height = 0
     this.childSet.children.forEach((childNode: SplootNode, i: number) => {
-      const isInlineChild = this.componentType === LayoutComponentType.CHILD_SET_INLINE
-      const childNodeBlock = new NodeBlock(this, childNode, selection, i, isInlineChild)
+      const childNodeBlock = new NodeBlock(this, childNode, selection, i)
       this.nodes.push(childNodeBlock)
     })
 
@@ -644,8 +643,7 @@ export class RenderedChildSetBlock implements ChildSetObserver {
   handleChildSetMutation(mutation: ChildSetMutation): void {
     if (mutation.type === ChildSetMutationType.INSERT) {
       mutation.nodes.forEach((node: SplootNode, idx: number) => {
-        const isInlineChild = this.componentType === LayoutComponentType.CHILD_SET_INLINE
-        const nodeBlock = new NodeBlock(this, node, this.selection, mutation.index + idx, isInlineChild)
+        const nodeBlock = new NodeBlock(this, node, this.selection, mutation.index + idx)
         this.nodes.splice(mutation.index + idx, 0, nodeBlock)
       })
       this.renumberChildren()

--- a/packages/editor/layout/rendered_node.ts
+++ b/packages/editor/layout/rendered_node.ts
@@ -59,8 +59,6 @@ export class NodeBlock implements NodeObserver {
   rightAttachedChildSet: string
   @observable
   leftBreadcrumbChildSet: string
-  @observable
-  isInlineChild: boolean
 
   @observable
   x: number
@@ -84,13 +82,7 @@ export class NodeBlock implements NodeObserver {
   @observable
   loopAnnotation: LoopAnnotation
 
-  constructor(
-    parentListBlock: RenderedChildSetBlock,
-    node: SplootNode,
-    selection: NodeSelection,
-    index: number,
-    isInlineChild: boolean
-  ) {
+  constructor(parentListBlock: RenderedChildSetBlock, node: SplootNode, selection: NodeSelection, index: number) {
     this.parentChildSet = parentListBlock
     this.selection = selection
     this.index = index
@@ -105,7 +97,6 @@ export class NodeBlock implements NodeObserver {
       this.node.registerObserver(this)
     }
     this.renderedInlineComponents = []
-    this.isInlineChild = isInlineChild
     this.blockWidth = 0
     this.marginLeft = 0
 
@@ -176,13 +167,7 @@ export class NodeBlock implements NodeObserver {
     let leftPos = this.x + nodeInlineSpacing
     let marginRight = 0
     this.marginLeft = 0
-    const numComponents = this.layout.components.length
     this.layout.components.forEach((component: LayoutComponent, idx) => {
-      const isLastInlineComponent =
-        !this.isInlineChild &&
-        (idx === numComponents - 1 ||
-          (idx === numComponents - 2 &&
-            this.layout.components[numComponents - 1].type === LayoutComponentType.CHILD_SET_BLOCK))
       if (component.type === LayoutComponentType.CHILD_SET_BLOCK) {
         const childSetBlock = this.renderedChildSets[component.identifier]
         childSetBlock.calculateDimensions(x + INDENT, y + this.rowHeight, selection)
@@ -211,14 +196,10 @@ export class NodeBlock implements NodeObserver {
         leftPos += width
         this.renderedInlineComponents.push(new RenderedInlineComponent(component, width))
 
-        if (isLastInlineComponent) {
-          this.rowHeight = Math.max(this.rowHeight, childSetBlock.height + this.marginTop)
-          // This minus 8 here accounts for the distance from the dot to the edge of the node.
-          // This is dumb tbh.
-          marginRight += Math.max(childSetBlock.width - 8, 0)
-        } else {
-          this.rowHeight = Math.max(this.rowHeight, childSetBlock.height + this.marginTop)
-        }
+        this.rowHeight = Math.max(this.rowHeight, childSetBlock.height + this.marginTop)
+        // This minus 8 here accounts for the distance from the dot to the edge of the node.
+        // This is dumb tbh.
+        marginRight += Math.max(childSetBlock.width - 8, 0)
       } else if (component.type === LayoutComponentType.CHILD_SET_TREE_BRACKETS) {
         const childSetBlock = this.renderedChildSets[component.identifier]
         childSetBlock.calculateDimensions(leftPos, y + this.marginTop, selection)
@@ -226,15 +207,10 @@ export class NodeBlock implements NodeObserver {
         this.blockWidth += width
         leftPos += width
         this.renderedInlineComponents.push(new RenderedInlineComponent(component, width))
-
-        if (isLastInlineComponent) {
-          this.rowHeight = Math.max(this.rowHeight, childSetBlock.height + this.marginTop)
-          // This minus 8 here accounts for the distance from the dot to the edge of the node.
-          // This is dumb tbh.
-          marginRight += Math.max(childSetBlock.width - 8, 0)
-        } else {
-          this.rowHeight = Math.max(this.rowHeight, childSetBlock.height + this.marginTop)
-        }
+        this.rowHeight = Math.max(this.rowHeight, childSetBlock.height + this.marginTop)
+        // This minus 8 here accounts for the distance from the dot to the edge of the node.
+        // This is dumb tbh.
+        marginRight += Math.max(childSetBlock.width - 8, 0)
       } else if (component.type === LayoutComponentType.CHILD_SET_INLINE) {
         const childSetBlock = this.renderedChildSets[component.identifier]
         childSetBlock.calculateDimensions(leftPos, y + this.marginTop, selection)

--- a/packages/editor/runtime/python_frame.tsx
+++ b/packages/editor/runtime/python_frame.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { StatementCapture } from '@splootcode/core/language/capture/runtime_capture'
 import { observer } from 'mobx-react'
 
 import { ChildSetMutation } from '@splootcode/core/language/mutations/child_set_mutations'
@@ -8,6 +7,7 @@ import { SplootPackage } from '@splootcode/core/language/projects/package'
 import { globalMutationDispatcher } from '@splootcode/core/language/mutations/mutation_dispatcher'
 
 import './python_frame.css'
+import { CapturePayload } from '@splootcode/core/language/capture/runtime_capture'
 
 export enum FrameState {
   DEAD = 0,
@@ -144,7 +144,7 @@ export class PythonFrame extends Component<ViewPageProps> {
         this.lastHeartbeatTimestamp = new Date()
         break
       case 'runtime_capture':
-        const capture = JSON.parse(event.data.capture) as StatementCapture
+        const capture = JSON.parse(event.data.capture) as CapturePayload
         this.updateRuntimeCapture(capture)
         break
       default:
@@ -152,13 +152,13 @@ export class PythonFrame extends Component<ViewPageProps> {
     }
   }
 
-  updateRuntimeCapture(capture: StatementCapture) {
+  updateRuntimeCapture(capture: CapturePayload) {
     // TODO: handle mutliple python files or different names.
     const filename = 'main.py'
     this.props.pkg
       .getLoadedFile(filename)
       .then((file) => {
-        file.rootNode.recursivelyApplyRuntimeCapture(capture)
+        file.rootNode.recursivelyApplyRuntimeCapture(capture.root)
       })
       .catch((err) => {
         console.warn(err)

--- a/packages/runtime-python/python/tests/convert_ast.py
+++ b/packages/runtime-python/python/tests/convert_ast.py
@@ -1,0 +1,118 @@
+from executor import OPERATORS
+import ast
+
+AST_OPERATORS = {type(value["ast"]): key for key, value in OPERATORS.items()}
+
+
+def convertOperator(astOp):
+  return AST_OPERATORS[type(astOp)]
+
+def SplootNode(type, childSets={}, properties={}):
+  return {
+    "type": type,
+    "childSets": childSets,
+    "properties": properties
+  }
+
+def generateAssignmentTarget(targets):
+  if len(targets) != 1:
+    raise Exception("Unsupported: multiple targets for assignment")
+  target = targets[0]
+  if type(target) == ast.Name:
+    return SplootNode('PYTHON_DECLARED_IDENTIFIER', {}, {"identifier": target.id})
+  
+  raise Exception(f"Unsupported target for assignment: {ast.dump(target)}")
+
+def generateAssignment(assignStatement):
+  return SplootNode("PYTHON_ASSIGNMENT", {
+    "left": [generateAssignmentTarget(assignStatement.targets)],
+    "right": [generateExpression(assignStatement.value)],
+  })
+
+def appendCallToken(callExpr, tokens):
+  arguments = [generateExpression(arg) for arg in callExpr.args]
+
+  if type(callExpr.func) == ast.Name:
+    name = callExpr.func.id
+    tokens.append(SplootNode('PYTHON_CALL_VARIABLE', {"arguments":arguments}, {"identifier": name}))
+  elif type(callExpr.func) == ast.Attribute:
+    raise Exception('Call expression on attribute (member) not yet supported.')
+  else:
+    raise Exception(f'Unsupported Call function expression: {ast.dump(callExpr.func)}')
+  
+
+def appendConstantToken(const, tokens):
+  if type(const.value) == str:
+    tokens.append(SplootNode("STRING_LITERAL", {}, {"value": const.value}))
+  elif type(const.value) == int:
+    tokens.append(SplootNode("NUMERIC_LITERAL", {}, {"value": const.value}))
+  else:
+    raise Exception(f'Unsupported constant: {const.value}')
+
+
+def appendBinaryOperatorExpression(binOp, tokens):
+  generateExpression(binOp.left, tokens)
+  tokens.append(SplootNode('PYTHON_BINARY_OPERATOR', {}, {'operator': convertOperator(binOp.op)}))
+  generateExpression(binOp.right, tokens)
+
+
+def appendCompareOperatorExpression(comp, tokens):
+  generateExpression(comp.left, tokens)
+  for op, comparator in zip(comp.ops, comp.comparators):
+    tokens.append(SplootNode('PYTHON_BINARY_OPERATOR', {}, {'operator': convertOperator(op)}))
+    generateExpression(comparator, tokens)
+
+
+def appendVariableReference(name, tokens):
+  tokens.append(SplootNode('PYTHON_VARIABLE_REFERENCE', {}, {'identifier': name.id}))
+
+def generateExpression(expr, tokens=None):
+  if tokens is None:
+    tokens = []
+
+  if type(expr) == ast.Call:
+    appendCallToken(expr, tokens)
+  elif type(expr) == ast.Constant:
+    appendConstantToken(expr, tokens)
+  elif type(expr) == ast.Name:
+    appendVariableReference(expr, tokens)
+  elif type(expr) == ast.BinOp:
+    appendBinaryOperatorExpression(expr, tokens)
+  elif type(expr) == ast.Compare:
+    appendCompareOperatorExpression(expr, tokens)
+  else:
+    raise Exception(f'Unrecognised expression type: {ast.dump(expr)}')
+  
+  return SplootNode("PYTHON_EXPRESSION", {"tokens": tokens})
+
+def generateWhile(whileStatement):
+  test = generateExpression(whileStatement.test)
+  body = [generateSplootStatement(s) for s in whileStatement.body]
+  return SplootNode("PYTHON_WHILE_LOOP", {
+    'condition': [test],
+    'block': body
+  })
+
+def generateSplootStatement(statement):
+  if type(statement) == ast.Expr:
+    expr = generateExpression(statement.value)
+    return SplootNode("PYTHON_STATEMENT", {"statement": [expr]})
+  elif type(statement) == ast.Assign:
+    assign = generateAssignment(statement)
+    return SplootNode("PYTHON_STATEMENT", {"statement": [assign]})
+  elif type(statement) == ast.While:
+    whileNode = generateWhile(statement)
+    return SplootNode("PYTHON_STATEMENT", {"statement": [whileNode]})
+  else:
+    raise Exception(f'Unrecognised statement type: {type(statement)}')
+  
+
+def splootFromPython(codeString):
+  tree = ast.parse(codeString)
+  fileNode = {"type":"PYTHON_FILE","properties":{},"childSets":{"body": []}}
+  
+  for statement in tree.body:
+    statementNode = generateSplootStatement(statement)
+    fileNode["childSets"]["body"].append(statementNode)
+
+  return fileNode

--- a/packages/runtime-python/python/tests/test_convert_ast.py
+++ b/packages/runtime-python/python/tests/test_convert_ast.py
@@ -68,3 +68,87 @@ class ParseTest(unittest.TestCase):
         self.maxDiff = None
         fileNode = splootFromPython(HELLO_NAME_CODE)
         self.assertEqual(fileNode, HELLO_NAME_SPLOOT)
+
+    def testFunction(self):
+        self.maxDiff = None
+        fileNode = splootFromPython('''
+def add(a, b):
+    print(a + b)
+add(3, 4)
+''')
+        self.assertEqual(fileNode, {
+"type":"PYTHON_FILE",
+"properties":{},
+"childSets":{
+    "body": [
+        {
+            "type": "PYTHON_STATEMENT",
+            "childSets": {
+                "statement": [{
+                    "type": "PYTHON_FUNCTION_DECLARATION",
+                    "properties": {},
+                    "childSets": {
+                        "identifier": [{'type': 'PYTHON_DECLARED_IDENTIFIER', 'childSets': {}, 'properties': {'identifier': 'add'}}],
+                        "body": [
+                            {
+                                "type": "PYTHON_STATEMENT",
+                                "childSets": {
+                                    "statement": [{
+                                        "type": "PYTHON_EXPRESSION",
+                                        "properties": {},
+                                        "childSets": {
+                                            "tokens": [
+                                                {"type": "PYTHON_CALL_VARIABLE",
+                                                'properties': {'identifier': 'print'},
+                                                "childSets": {
+                                                    "arguments": [
+                                                        {"type": "PYTHON_EXPRESSION", "properties": {}, "childSets": {'tokens': [
+                                                            {'type': 'PYTHON_VARIABLE_REFERENCE', 'childSets': {}, 'properties': {'identifier': 'a'}},
+                                                            {'type': 'PYTHON_BINARY_OPERATOR', 'childSets': {}, 'properties': {'operator': '+'}},
+                                                            {'type': 'PYTHON_VARIABLE_REFERENCE', 'childSets': {}, 'properties': {'identifier': 'b'}},
+                                                        ]}},
+                                                    ]
+                                                }}
+                                            ],
+                                        }
+                                    }]
+                                },
+                                "properties": {}
+                            }
+                        ],
+                        "params": [
+                            {'type': 'PYTHON_DECLARED_IDENTIFIER', 'childSets': {}, 'properties': {'identifier': 'a'}},
+                            {'type': 'PYTHON_DECLARED_IDENTIFIER', 'childSets': {}, 'properties': {'identifier': 'b'}}
+                        ]
+                    }
+                }]
+            },
+            "properties": {}
+        },
+        {
+            "type": "PYTHON_STATEMENT",
+            "childSets": {
+                "statement": [{
+                    "type": "PYTHON_EXPRESSION",
+                    "properties": {},
+                    "childSets": {
+                        "tokens": [
+                            {"type": "PYTHON_CALL_VARIABLE", 'properties': {'identifier': 'add'}, 'childSets':{
+                                'arguments': [
+                                    {"type": "PYTHON_EXPRESSION", "properties": {}, "childSets": {
+                                        'tokens': [{'type': 'NUMERIC_LITERAL', 'childSets': {}, 'properties': {'value': 3}}]
+                                    }},
+                                    {"type": "PYTHON_EXPRESSION", "properties": {}, "childSets": {
+                                        'tokens': [{'type': 'NUMERIC_LITERAL', 'childSets': {}, 'properties': {'value': 4}}]
+                                    }},
+                                ]
+                            }}
+                        ],
+                    }
+                }]
+            },
+            "properties": {}
+        }
+    ]
+}
+})

--- a/packages/runtime-python/python/tests/test_convert_ast.py
+++ b/packages/runtime-python/python/tests/test_convert_ast.py
@@ -1,0 +1,70 @@
+import unittest
+
+from .convert_ast import splootFromPython 
+
+HELLO_NAME_SPLOOT = {
+    "type":"PYTHON_FILE",
+    "properties":{},
+    "childSets":{
+        "body":[
+            {"type":"PYTHON_STATEMENT","properties":{},"childSets":{"statement":[
+                {"type":"PYTHON_EXPRESSION","properties":{},"childSets":{
+                    "tokens":[
+                        {"type":"PYTHON_CALL_VARIABLE","properties":{"identifier":"print"},
+                        "childSets":{"arguments":[
+                            {"type":"PYTHON_EXPRESSION","properties":{},"childSets":{"tokens":[
+                                {"type":"STRING_LITERAL","properties":{"value":"Hello!"},"childSets":{}}
+                            ]}}
+                        ]}}
+                    ]
+                }}
+            ]}},
+            {"type":"PYTHON_STATEMENT","properties":{},"childSets":{"statement":[
+                {"type":"PYTHON_ASSIGNMENT","properties":{},"childSets":{
+                    "left":[{"type":"PYTHON_DECLARED_IDENTIFIER","properties":{"identifier":"name"},"childSets":{}}],
+                    "right":[{"type":"PYTHON_EXPRESSION","properties":{},"childSets":{
+                        "tokens":[{"type":"PYTHON_CALL_VARIABLE","properties":{"identifier":"input"},"childSets":{
+                            "arguments":[{"type":"PYTHON_EXPRESSION","properties":{},"childSets":{
+                                "tokens":[{"type":"STRING_LITERAL","properties":{"value":"What is your name? "},"childSets":{}}]
+                            }}]
+                        }}]
+                    }}]
+                }},
+        ]}},
+            {"type":"PYTHON_STATEMENT","properties":{},"childSets":{"statement":[
+                {"type":"PYTHON_EXPRESSION","properties":{},"childSets":{
+                    "tokens":[
+                        {"type":"PYTHON_CALL_VARIABLE","properties":{"identifier":"print"},"childSets":{
+                            "arguments":[{"type":"PYTHON_EXPRESSION","properties":{},"childSets":{"tokens":[
+                                {"type":"STRING_LITERAL","properties":{"value":"Hello, "},"childSets":{}},
+                                {"type":"PYTHON_BINARY_OPERATOR","properties":{"operator":"+"},"childSets":{}},
+                                {"type":"PYTHON_VARIABLE_REFERENCE","properties":{"identifier":"name"},"childSets":{}}
+                            ]}}]
+                        }}
+                    ]
+                }}
+            ]}},
+        ]
+    }
+}
+
+HELLO_NAME_CODE = '''
+print('Hello!')
+name = input('What is your name? ')
+print('Hello, ' + name)
+'''
+
+
+class ParseTest(unittest.TestCase):
+    def testEmptyCode(self):
+        pythonFileNode = splootFromPython('')
+        self.assertEqual(pythonFileNode, {
+            'type': 'PYTHON_FILE',
+            'childSets': {'body': []},
+            'properties': {}
+        })
+
+    def testHelloName(self):
+        self.maxDiff = None
+        fileNode = splootFromPython(HELLO_NAME_CODE)
+        self.assertEqual(fileNode, HELLO_NAME_SPLOOT)

--- a/packages/runtime-python/python/tests/test_execute.py
+++ b/packages/runtime-python/python/tests/test_execute.py
@@ -1,0 +1,87 @@
+import io
+import contextlib
+import unittest
+
+from executor import executePythonFile, wrapStdout
+from .convert_ast import splootFromPython 
+
+
+class ExecuteTest(unittest.TestCase):
+    def testHelloWorld(self):
+        splootFile = splootFromPython('print("Hello, World!")')
+        
+        f = io.StringIO()
+        f.write = wrapStdout(f.write)
+        with contextlib.redirect_stdout(f):
+            cap = executePythonFile(splootFile)
+
+        self.assertEqual(cap, {
+            'type': 'PYTHON_FILE',
+            'data': {
+                'body': [
+                    {
+                        'type': 'PYTHON_EXPRESSION',
+                        'data': {'result': 'None', 'resultType': 'NoneType'},
+                        'sideEffects': [
+                            {"type": "stdout", "value": 'Hello, World!'},
+                            {"type": "stdout", "value": '\n'},
+                        ]
+                    }
+                ]
+            }
+        })
+        
+        self.assertEqual(f.getvalue(), "Hello, World!\n")
+    
+    def testWhileLoop(self):
+        self.maxDiff = None
+        splootFile = splootFromPython('''
+count = 0
+while count < 3:
+    count = count + 1
+''')
+        cap = executePythonFile(splootFile)
+
+        self.assertEqual(cap, {
+            'type': 'PYTHON_FILE',
+            'data': {
+                'body': [
+                    {
+                        'type': 'PYTHON_ASSIGNMENT',
+                        'data': {'result': '0', 'resultType': 'int'}
+                    },
+                    {
+                        'type': 'PYTHON_WHILE_LOOP',
+                        'data': {'frames': [
+                            {
+                                'type': 'PYTHON_WHILE_LOOP_ITERATION',
+                                'data':{
+                                    'condition': [{'data': {'result': 'True', 'resultType': 'bool'}}],
+                                    'block': [{'type': 'PYTHON_ASSIGNMENT', 'data': {'result': '1', 'resultType': 'int'}}],
+                                },
+                            },
+                            {
+                                'type': 'PYTHON_WHILE_LOOP_ITERATION',
+                                'data':{
+                                    'condition': [{'data': {'result': 'True', 'resultType': 'bool'}}],
+                                    'block': [{'type': 'PYTHON_ASSIGNMENT', 'data': {'result': '2', 'resultType': 'int'}}],
+                                },
+                            },
+                            {
+                                'type': 'PYTHON_WHILE_LOOP_ITERATION',
+                                'data':{
+                                    'condition': [{'data': {'result': 'True', 'resultType': 'bool'}}],
+                                    'block': [{'type': 'PYTHON_ASSIGNMENT', 'data': {'result': '3', 'resultType': 'int'}}],
+                                },
+                            },
+                            {
+                                'type': 'PYTHON_WHILE_LOOP_ITERATION',
+                                'data':{
+                                    'condition': [{'data': {'result': 'False', 'resultType': 'bool'}}],
+                                },
+                            }
+                        ]},
+                    }
+                ]
+            }
+        })

--- a/packages/runtime-python/runtime/webworker.js
+++ b/packages/runtime-python/runtime/webworker.js
@@ -55,7 +55,7 @@ let nodetree = null
 
 const run = async () => {
   try {
-    await pyodide.runPythonAsync(executorCode)
+    await pyodide.runPython(executorCode)
   } catch (err) {
     postMessage({
       type: 'stdout',
@@ -98,6 +98,7 @@ const initialise = async () => {
       })
     },
   })
+  pyodide.globals.set('__name__', '__main__')
   postMessage({
     type: 'ready',
   })

--- a/src/pages/python_editor.tsx
+++ b/src/pages/python_editor.tsx
@@ -24,7 +24,7 @@ export const PythonEditorPanels = (props: WebEditorProps) => {
     const file = pack.getDefaultFile()
     const selectFile = (pack: SplootPackage, file: SplootFile) => {
       const editorState = new EditorState()
-      const newRootNode = new NodeBlock(null, file.rootNode, editorState.selection, 0, false)
+      const newRootNode = new NodeBlock(null, file.rootNode, editorState.selection, 0)
       editorState.selection.setRootNode(newRootNode)
       editorState.setRootNode(newRootNode)
       setSelectedFile(editorState)


### PR DESCRIPTION
Includes:
 * Function node
 * Refactoring of right-attached childset to allow for multiple nodes (like tokens)
 * Tests for Python execution
 * Some starting code for converting Python code into serialised SplootNodes
 * Adds concept of 'detached' frames for cases where execution order does not match tree structure