### PR TITLE
Adding comments into Sploot!

### DIFF
--- a/packages/language-python/src/nodes/python_comment.ts
+++ b/packages/language-python/src/nodes/python_comment.ts
@@ -25,13 +25,15 @@ import { PythonNode } from './python_node'
 export const PYTHON_COMMENT = 'PY_COMMENT'
 
 class CommentGenerator implements SuggestionGenerator {
+    // like the name implies, these are autocorrect suggestions that always remain the same 
   staticSuggestions(parent: ParentReference, index: number) {
     console.log('static suggestions!')
     const emptyComment = new PythonComment(null, '')
+    // this is
     const suggestedNode = new SuggestedNode(emptyComment, 'empty comment', 'comment', true, 'comment')
     return [suggestedNode]
   }
-
+    // while these ones change as you type 
   dynamicSuggestions(parent: ParentReference, index: number, textInput: string) {
     console.log('dynamicSuggestions!!')
     if (textInput.startsWith("'") || textInput.startsWith('"')) {
@@ -61,6 +63,7 @@ export class PythonComment extends PythonNode {
     return 'value'
   }
 
+//   helps the code be parsed as Code :sweat:
   generateParseTree(parseMapper: ParseMapper): StringNode {
     const val = this.getValue()
     return {
@@ -82,10 +85,12 @@ export class PythonComment extends PythonNode {
     }
   }
 
+//   turns the comment's serialized JSON into a Python Comment node
   static deserializer(serializedNode: SerializedNode): PythonComment {
     return new PythonComment(null, serializedNode.properties.value)
   }
 
+// this is what the Type Loader uses to register this
   static register() {
     console.log('register is being called')
     const comment = new TypeRegistration()

--- a/packages/language-python/src/nodes/python_comment.ts
+++ b/packages/language-python/src/nodes/python_comment.ts
@@ -1,0 +1,111 @@
+import { ParseNodeType, StringNode, StringTokenFlags, TokenType } from 'structured-pyright'
+
+import {
+  HighlightColorCategory,
+  LayoutComponent,
+  LayoutComponentType,
+  NodeBoxType,
+  NodeCategory,
+  NodeLayout,
+  ParentReference,
+  SerializedNode,
+  SplootNode,
+  SuggestedNode,
+  SuggestionGenerator,
+  TypeRegistration,
+  getAutocompleteRegistry,
+  registerAutocompleter,
+  registerNodeCateogry,
+  registerType,
+} from '@splootcode/core'
+import { PYTHON_EXPRESSION, PythonExpression } from './python_expression'
+import { ParseMapper } from '../analyzer/python_analyzer'
+import { PythonNode } from './python_node'
+
+export const PYTHON_COMMENT = 'PY_COMMENT'
+
+class CommentGenerator implements SuggestionGenerator {
+  staticSuggestions(parent: ParentReference, index: number) {
+    console.log('static suggestions!')
+    const emptyComment = new PythonComment(null, '')
+    const suggestedNode = new SuggestedNode(emptyComment, 'empty comment', 'comment', true, 'comment')
+    return [suggestedNode]
+  }
+
+  dynamicSuggestions(parent: ParentReference, index: number, textInput: string) {
+    console.log('dynamicSuggestions!!')
+    if (textInput.startsWith("'") || textInput.startsWith('"')) {
+      let value = textInput.slice(1)
+      if (value.length !== 0 && value[value.length - 1] === textInput[0]) {
+        value = value.slice(0, value.length - 1)
+      }
+      const customString = new PythonComment(null, value)
+      const suggestedNode = new SuggestedNode(customString, `string ${value}`, textInput, true, 'string')
+      return [suggestedNode]
+    }
+    return []
+  }
+}
+
+export class PythonComment extends PythonNode {
+  constructor(parentReference: ParentReference, value: string) {
+    super(parentReference, PYTHON_COMMENT)
+    this.properties = { value: value }
+  }
+
+  getValue() {
+    return this.properties.value
+  }
+
+  getEditableProperty() {
+    return 'value'
+  }
+
+  generateParseTree(parseMapper: ParseMapper): StringNode {
+    const val = this.getValue()
+    return {
+      nodeType: ParseNodeType.String,
+      id: parseMapper.getNextId(),
+      length: 0,
+      start: 0,
+      value: val,
+      hasUnescapeErrors: false,
+      token: {
+        escapedValue: val,
+        start: 0,
+        length: 0,
+        flags: StringTokenFlags.None,
+        type: TokenType.String,
+        prefixLength: 0,
+        quoteMarkLength: 0,
+      },
+    }
+  }
+
+  static deserializer(serializedNode: SerializedNode): PythonComment {
+    return new PythonComment(null, serializedNode.properties.value)
+  }
+
+  static register() {
+    console.log('register is being called')
+    const comment = new TypeRegistration()
+    comment.typeName = PYTHON_COMMENT
+    comment.deserializer = PythonComment.deserializer
+    comment.properties = ['value']
+    comment.layout = new NodeLayout(HighlightColorCategory.VARIABLE, [
+      new LayoutComponent(LayoutComponentType.CAP, '#'),
+      new LayoutComponent(LayoutComponentType.PROPERTY, 'value'),
+    ])
+    comment.pasteAdapters[PYTHON_EXPRESSION] = (node: SplootNode) => {
+      const exp = new PythonExpression(null)
+      exp.getTokenSet().addChild(node)
+      return exp
+    }
+    registerType(comment)
+    registerNodeCateogry(PYTHON_COMMENT, NodeCategory.PythonExpressionToken)
+    registerAutocompleter(NodeCategory.PythonExpressionToken, new CommentGenerator())
+
+    const registry = getAutocompleteRegistry()
+    registry.registerPrefixOverride('#', NodeCategory.PythonExpressionToken, new CommentGenerator())
+  }
+}

--- a/packages/language-python/src/nodes/python_comment.ts
+++ b/packages/language-python/src/nodes/python_comment.ts
@@ -1,10 +1,7 @@
-import { ParseNodeType, StringNode, StringTokenFlags, TokenType } from 'structured-pyright'
-
 import {
   HighlightColorCategory,
   LayoutComponent,
   LayoutComponentType,
-  NodeBoxType,
   NodeCategory,
   NodeLayout,
   ParentReference,
@@ -18,14 +15,14 @@ import {
   registerNodeCateogry,
   registerType,
 } from '@splootcode/core'
-import { PYTHON_EXPRESSION, PythonExpression } from './python_expression'
+import { PYTHON_STATEMENT, PythonStatement } from './python_statement'
 import { ParseMapper } from '../analyzer/python_analyzer'
 import { PythonNode } from './python_node'
 
 export const PYTHON_COMMENT = 'PY_COMMENT'
 
 class CommentGenerator implements SuggestionGenerator {
-    // like the name implies, these are autocorrect suggestions that always remain the same 
+  // like the name implies, these are autocorrect suggestions that always remain the same
   staticSuggestions(parent: ParentReference, index: number) {
     console.log('static suggestions!')
     const emptyComment = new PythonComment(null, '')
@@ -33,7 +30,7 @@ class CommentGenerator implements SuggestionGenerator {
     const suggestedNode = new SuggestedNode(emptyComment, 'empty comment', 'comment', true, 'comment')
     return [suggestedNode]
   }
-    // while these ones change as you type 
+  // while these ones change as you type
   dynamicSuggestions(parent: ParentReference, index: number, textInput: string) {
     console.log('dynamicSuggestions!!')
     if (textInput.startsWith("'") || textInput.startsWith('"')) {
@@ -63,54 +60,37 @@ export class PythonComment extends PythonNode {
     return 'value'
   }
 
-//   helps the code be parsed as Code :sweat:
-  generateParseTree(parseMapper: ParseMapper): StringNode {
-    const val = this.getValue()
-    return {
-      nodeType: ParseNodeType.String,
-      id: parseMapper.getNextId(),
-      length: 0,
-      start: 0,
-      value: val,
-      hasUnescapeErrors: false,
-      token: {
-        escapedValue: val,
-        start: 0,
-        length: 0,
-        flags: StringTokenFlags.None,
-        type: TokenType.String,
-        prefixLength: 0,
-        quoteMarkLength: 0,
-      },
-    }
+  //  No reason to create a parse tree for comments
+  generateParseTree(parseMapper: ParseMapper): any {
+    return null
   }
 
-//   turns the comment's serialized JSON into a Python Comment node
+  //   turns the comment's serialized JSON into a Python Comment node
   static deserializer(serializedNode: SerializedNode): PythonComment {
     return new PythonComment(null, serializedNode.properties.value)
   }
 
-// this is what the Type Loader uses to register this
+  // this is what the Type Loader uses to register this
   static register() {
     console.log('register is being called')
-    const comment = new TypeRegistration()
-    comment.typeName = PYTHON_COMMENT
-    comment.deserializer = PythonComment.deserializer
-    comment.properties = ['value']
-    comment.layout = new NodeLayout(HighlightColorCategory.VARIABLE, [
+    const typeRegistration = new TypeRegistration()
+    typeRegistration.typeName = PYTHON_COMMENT
+    typeRegistration.deserializer = PythonComment.deserializer
+    typeRegistration.properties = ['value']
+    typeRegistration.layout = new NodeLayout(HighlightColorCategory.VARIABLE, [
       new LayoutComponent(LayoutComponentType.CAP, '#'),
       new LayoutComponent(LayoutComponentType.PROPERTY, 'value'),
     ])
-    comment.pasteAdapters[PYTHON_EXPRESSION] = (node: SplootNode) => {
-      const exp = new PythonExpression(null)
-      exp.getTokenSet().addChild(node)
-      return exp
+    typeRegistration.pasteAdapters[PYTHON_STATEMENT] = (node: SplootNode) => {
+      const statement = new PythonStatement(null)
+      statement.getStatement().addChild(node)
+      return statement
     }
-    registerType(comment)
-    registerNodeCateogry(PYTHON_COMMENT, NodeCategory.PythonExpressionToken)
-    registerAutocompleter(NodeCategory.PythonExpressionToken, new CommentGenerator())
+    registerType(typeRegistration)
+    registerNodeCateogry(PYTHON_COMMENT, NodeCategory.PythonStatementContents)
+    registerAutocompleter(NodeCategory.PythonStatementContents, new CommentGenerator())
 
     const registry = getAutocompleteRegistry()
-    registry.registerPrefixOverride('#', NodeCategory.PythonExpressionToken, new CommentGenerator())
+    registry.registerPrefixOverride('#', NodeCategory.PythonStatementContents, new CommentGenerator())
   }
 }

--- a/packages/language-python/src/nodes/python_comment.ts
+++ b/packages/language-python/src/nodes/python_comment.ts
@@ -22,24 +22,21 @@ import { PythonNode } from './python_node'
 export const PYTHON_COMMENT = 'PY_COMMENT'
 
 class CommentGenerator implements SuggestionGenerator {
-  // like the name implies, these are autocorrect suggestions that always remain the same
+  // like the name implies, these are autocorrect suggestions that always remain the same ie static
   staticSuggestions(parent: ParentReference, index: number) {
-    console.log('static suggestions!')
     const emptyComment = new PythonComment(null, '')
-    // this is
     const suggestedNode = new SuggestedNode(emptyComment, 'empty comment', 'comment', true, 'comment')
     return [suggestedNode]
   }
   // while these ones change as you type
   dynamicSuggestions(parent: ParentReference, index: number, textInput: string) {
-    console.log('dynamicSuggestions!!')
-    if (textInput.startsWith("'") || textInput.startsWith('"')) {
+    if (textInput.startsWith('#')) {
       let value = textInput.slice(1)
       if (value.length !== 0 && value[value.length - 1] === textInput[0]) {
         value = value.slice(0, value.length - 1)
       }
-      const customString = new PythonComment(null, value)
-      const suggestedNode = new SuggestedNode(customString, `string ${value}`, textInput, true, 'string')
+      const customComment = new PythonComment(null, value)
+      const suggestedNode = new SuggestedNode(customComment, `comment ${value}`, textInput, true, 'comment')
       return [suggestedNode]
     }
     return []
@@ -56,11 +53,12 @@ export class PythonComment extends PythonNode {
     return this.properties.value
   }
 
+  // without this, we cannot edit the contents of a comment
   getEditableProperty() {
     return 'value'
   }
 
-  //  No reason to create a parse tree for comments
+  //  No real reason to create a parse tree for comments, so return null
   generateParseTree(parseMapper: ParseMapper): any {
     return null
   }
@@ -70,9 +68,8 @@ export class PythonComment extends PythonNode {
     return new PythonComment(null, serializedNode.properties.value)
   }
 
-  // this is what the Type Loader uses to register this
+  // this is what the Type Loader uses to register the comment as an accepted node in sploot
   static register() {
-    console.log('register is being called')
     const typeRegistration = new TypeRegistration()
     typeRegistration.typeName = PYTHON_COMMENT
     typeRegistration.deserializer = PythonComment.deserializer

--- a/packages/language-python/src/type_loader.ts
+++ b/packages/language-python/src/type_loader.ts
@@ -36,6 +36,7 @@ import { registerArgumentAutocompleters } from './nodes/scope_argument_autocompl
 import { registerMemberAutocompleters } from './nodes/scope_member_autocompleter'
 import { registerPythonAutocompleters } from './nodes/scope_autocompleter'
 import { resolvePasteAdapters } from '@splootcode/core'
+import { PythonComment } from './nodes/python_comment'
 
 export function loadPythonTypes() {
   PythonStringLiteral.register()
@@ -72,6 +73,7 @@ export function loadPythonTypes() {
   PythonSubscript.register()
   PythonTuple.register()
   PythonWhileLoop.register()
+  PythonComment.register()
   registerPythonAutocompleters()
   registerMemberAutocompleters()
   registerArgumentAutocompleters()

--- a/python/executor.py
+++ b/python/executor.py
@@ -643,6 +643,8 @@ def generateAstStatement(sploot_node):
         return generateBreakStatement(sploot_node)
     elif sploot_node["type"] == "PY_CONTINUE":
         return generateContinueStatement(sploot_node)
+    elif sploot_node["type"] == "PY_COMMENT":
+        return None
     else:
         print("Error: Unrecognised statement type: ", sploot_node["type"])
         return None


### PR DESCRIPTION
## How they were implemented
- Initially copied the implementation for strings
- Changed comments to be statements instead of expressions to make implementing the `generateParseTree` method a lot easier. The main drawback of this is that comments cannot be placed to the right of a line of code, and always have to be on their own line.

## Expected behaviour
- Comments work!
- They do not interfere with the running of code and should not print any errors into the console on the right
![Screen Recording 2022-12-28 at 2 10 50 pm](https://user-images.githubusercontent.com/80010127/209752246-b5b0f6e1-ea6c-4766-be3c-f163f18506ec.gif)

## Issues I'm still figuring out
- After autocompleting 'comment', have the comment block immediately be editable (rather than having to double click into it to type in a comment) 