### PR TITLE
Adding comments into Sploot! (#105)

### DIFF
--- a/packages/core/src/colors.ts
+++ b/packages/core/src/colors.ts
@@ -14,6 +14,7 @@ export enum HighlightColorCategory {
   HTML_ATTRIBUTE,
   STYLE_RULE,
   STYLE_PROPERTY,
+  COMMENT,
 }
 
 export enum ColorUsageType {
@@ -41,6 +42,8 @@ function colorBase(category: HighlightColorCategory): string {
       return 'code-purple'
     case HighlightColorCategory.CONTROL:
       return 'code-purple'
+    case HighlightColorCategory.COMMENT:
+      return 'code-comment'
   }
   return 'code-neutral'
 }

--- a/packages/editor/src/components/editor.css
+++ b/packages/editor/src/components/editor.css
@@ -53,6 +53,10 @@ text {
 
 :root {
   --string-font: 'Inconsolata', monospace;
+  /* Comments are special because the cap is brighter than the text. */
+  --code-comment-200: rgb(164, 166, 180);
+  --code-comment-700: rgb(217, 220, 226);
+
   --code-neutral-200: rgb(226, 226, 226);
   --code-neutral-700: rgb(97, 97, 96);
   --code-yellow-200: rgb(255 254 196);

--- a/packages/language-python/src/nodes/python_comment.ts
+++ b/packages/language-python/src/nodes/python_comment.ts
@@ -7,6 +7,7 @@ import {
   ParentReference,
   SerializedNode,
   SplootNode,
+  StatementCapture,
   SuggestedNode,
   SuggestionGenerator,
   TypeRegistration,
@@ -46,7 +47,7 @@ class CommentGenerator implements SuggestionGenerator {
 export class PythonComment extends PythonNode {
   constructor(parentReference: ParentReference, value: string) {
     super(parentReference, PYTHON_COMMENT)
-    this.properties = { value: value }
+    this.setProperty('value', value)
   }
 
   getValue() {
@@ -56,6 +57,11 @@ export class PythonComment extends PythonNode {
   // without this, we cannot edit the contents of a comment
   getEditableProperty() {
     return 'value'
+  }
+
+  recursivelyApplyRuntimeCapture(capture: StatementCapture): boolean {
+    // Comments won't get runtime annotations.
+    return false
   }
 
   //  No real reason to create a parse tree for comments, so return null
@@ -74,7 +80,7 @@ export class PythonComment extends PythonNode {
     typeRegistration.typeName = PYTHON_COMMENT
     typeRegistration.deserializer = PythonComment.deserializer
     typeRegistration.properties = ['value']
-    typeRegistration.layout = new NodeLayout(HighlightColorCategory.VARIABLE, [
+    typeRegistration.layout = new NodeLayout(HighlightColorCategory.COMMENT, [
       new LayoutComponent(LayoutComponentType.CAP, '#'),
       new LayoutComponent(LayoutComponentType.PROPERTY, 'value'),
     ])

--- a/packages/language-python/src/nodes/python_comment.ts
+++ b/packages/language-python/src/nodes/python_comment.ts
@@ -1,0 +1,93 @@
+import {
+  HighlightColorCategory,
+  LayoutComponent,
+  LayoutComponentType,
+  NodeCategory,
+  NodeLayout,
+  ParentReference,
+  SerializedNode,
+  SplootNode,
+  SuggestedNode,
+  SuggestionGenerator,
+  TypeRegistration,
+  getAutocompleteRegistry,
+  registerAutocompleter,
+  registerNodeCateogry,
+  registerType,
+} from '@splootcode/core'
+import { PYTHON_STATEMENT, PythonStatement } from './python_statement'
+import { ParseMapper } from '../analyzer/python_analyzer'
+import { PythonNode } from './python_node'
+
+export const PYTHON_COMMENT = 'PY_COMMENT'
+
+class CommentGenerator implements SuggestionGenerator {
+  // like the name implies, these are autocorrect suggestions that always remain the same ie static
+  staticSuggestions(parent: ParentReference, index: number) {
+    const emptyComment = new PythonComment(null, '')
+    const suggestedNode = new SuggestedNode(emptyComment, 'empty comment', 'comment', true, 'comment')
+    return [suggestedNode]
+  }
+  // while these ones change as you type
+  dynamicSuggestions(parent: ParentReference, index: number, textInput: string) {
+    if (textInput.startsWith('#')) {
+      let value = textInput.slice(1)
+      if (value.length !== 0 && value[value.length - 1] === textInput[0]) {
+        value = value.slice(0, value.length - 1)
+      }
+      const customComment = new PythonComment(null, value)
+      const suggestedNode = new SuggestedNode(customComment, `comment ${value}`, textInput, true, 'comment')
+      return [suggestedNode]
+    }
+    return []
+  }
+}
+
+export class PythonComment extends PythonNode {
+  constructor(parentReference: ParentReference, value: string) {
+    super(parentReference, PYTHON_COMMENT)
+    this.properties = { value: value }
+  }
+
+  getValue() {
+    return this.properties.value
+  }
+
+  // without this, we cannot edit the contents of a comment
+  getEditableProperty() {
+    return 'value'
+  }
+
+  //  No real reason to create a parse tree for comments, so return null
+  generateParseTree(parseMapper: ParseMapper): any {
+    return null
+  }
+
+  //   turns the comment's serialized JSON into a Python Comment node
+  static deserializer(serializedNode: SerializedNode): PythonComment {
+    return new PythonComment(null, serializedNode.properties.value)
+  }
+
+  // this is what the Type Loader uses to register the comment as an accepted node in sploot
+  static register() {
+    const typeRegistration = new TypeRegistration()
+    typeRegistration.typeName = PYTHON_COMMENT
+    typeRegistration.deserializer = PythonComment.deserializer
+    typeRegistration.properties = ['value']
+    typeRegistration.layout = new NodeLayout(HighlightColorCategory.VARIABLE, [
+      new LayoutComponent(LayoutComponentType.CAP, '#'),
+      new LayoutComponent(LayoutComponentType.PROPERTY, 'value'),
+    ])
+    typeRegistration.pasteAdapters[PYTHON_STATEMENT] = (node: SplootNode) => {
+      const statement = new PythonStatement(null)
+      statement.getStatement().addChild(node)
+      return statement
+    }
+    registerType(typeRegistration)
+    registerNodeCateogry(PYTHON_COMMENT, NodeCategory.PythonStatementContents)
+    registerAutocompleter(NodeCategory.PythonStatementContents, new CommentGenerator())
+
+    const registry = getAutocompleteRegistry()
+    registry.registerPrefixOverride('#', NodeCategory.PythonStatementContents, new CommentGenerator())
+  }
+}

--- a/packages/language-python/src/nodes/python_statement.ts
+++ b/packages/language-python/src/nodes/python_statement.ts
@@ -58,7 +58,7 @@ export class PythonStatement extends PythonNode {
     const child = this.getStatement().getChild(0)
     const childParseNode = (child as PythonNode).generateParseTree(parseMapper)
     if (!childParseNode) {
-      console.warn(`No parse for child node type, ${child.type}`)
+      // Expected for some nodes (like comments)
       return null
     }
     if (childParseNode && statementNodes.includes(childParseNode.nodeType)) {

--- a/packages/language-python/src/nodes/tests/parsetree.test.ts
+++ b/packages/language-python/src/nodes/tests/parsetree.test.ts
@@ -1,3 +1,4 @@
+import { PYTHON_COMMENT } from '../python_comment'
 import { ParseMapper } from '../../analyzer/python_analyzer'
 import { ParseNodeType, isExpressionNode } from 'structured-pyright'
 import { PythonNode } from '../python_node'
@@ -15,6 +16,10 @@ describe('python parse tree generation', () => {
   test('statement nodes generate valid parse trees', () => {
     const examples: PythonNode[] = getEmptyStatementNodes()
     examples.forEach((node) => {
+      if (node.type === PYTHON_COMMENT) {
+        // Skip comments, they don't need to generate parse trees.
+        return
+      }
       const statement = new PythonStatement(null)
       statement.getStatement().addChild(node)
       const parseTree = statement.generateParseTree(new ParseMapper())

--- a/packages/language-python/src/nodes/tests/single_examples.ts
+++ b/packages/language-python/src/nodes/tests/single_examples.ts
@@ -5,6 +5,7 @@ import { PythonBrackets } from '../python_brackets'
 import { PythonBreak } from '../python_break'
 import { PythonCallMember } from '../python_call_member'
 import { PythonCallVariable } from '../python_call_variable'
+import { PythonComment } from '../python_comment'
 import { PythonContinue } from '../python_continue'
 import { PythonDictionary } from '../python_dictionary'
 import { PythonExpression } from '../python_expression'
@@ -38,6 +39,7 @@ export function getEmptyStatementNodes(): PythonNode[] {
     new PythonImport(null),
     new PythonReturn(null),
     new PythonWhileLoop(null),
+    new PythonComment(null, 'something'),
   ]
 }
 

--- a/packages/language-python/src/type_loader.ts
+++ b/packages/language-python/src/type_loader.ts
@@ -36,6 +36,7 @@ import { registerArgumentAutocompleters } from './nodes/scope_argument_autocompl
 import { registerMemberAutocompleters } from './nodes/scope_member_autocompleter'
 import { registerPythonAutocompleters } from './nodes/scope_autocompleter'
 import { resolvePasteAdapters } from '@splootcode/core'
+import { PythonComment } from './nodes/python_comment'
 
 export function loadPythonTypes() {
   PythonStringLiteral.register()
@@ -72,6 +73,7 @@ export function loadPythonTypes() {
   PythonSubscript.register()
   PythonTuple.register()
   PythonWhileLoop.register()
+  PythonComment.register()
   registerPythonAutocompleters()
   registerMemberAutocompleters()
   registerArgumentAutocompleters()

--- a/packages/language-python/src/type_loader.ts
+++ b/packages/language-python/src/type_loader.ts
@@ -6,6 +6,7 @@ import { PythonBrackets } from './nodes/python_brackets'
 import { PythonBreak } from './nodes/python_break'
 import { PythonCallMember } from './nodes/python_call_member'
 import { PythonCallVariable } from './nodes/python_call_variable'
+import { PythonComment } from './nodes/python_comment'
 import { PythonContinue } from './nodes/python_continue'
 import { PythonDeclaredIdentifier } from './nodes/declared_identifier'
 import { PythonDictionary } from './nodes/python_dictionary'
@@ -36,7 +37,6 @@ import { registerArgumentAutocompleters } from './nodes/scope_argument_autocompl
 import { registerMemberAutocompleters } from './nodes/scope_member_autocompleter'
 import { registerPythonAutocompleters } from './nodes/scope_autocompleter'
 import { resolvePasteAdapters } from '@splootcode/core'
-import { PythonComment } from './nodes/python_comment'
 
 export function loadPythonTypes() {
   PythonStringLiteral.register()
@@ -50,6 +50,7 @@ export function loadPythonTypes() {
   PythonBreak.register()
   PythonCallMember.register()
   PythonCallVariable.register()
+  PythonComment.register()
   PythonContinue.register()
   PythonDictionary.register()
   PythonElifBlock.register()
@@ -73,7 +74,7 @@ export function loadPythonTypes() {
   PythonSubscript.register()
   PythonTuple.register()
   PythonWhileLoop.register()
-  PythonComment.register()
+
   registerPythonAutocompleters()
   registerMemberAutocompleters()
   registerArgumentAutocompleters()

--- a/python/executor.py
+++ b/python/executor.py
@@ -643,6 +643,8 @@ def generateAstStatement(sploot_node):
         return generateBreakStatement(sploot_node)
     elif sploot_node["type"] == "PY_CONTINUE":
         return generateContinueStatement(sploot_node)
+    elif sploot_node["type"] == "PY_COMMENT":
+        return None
     else:
         print("Error: Unrecognised statement type: ", sploot_node["type"])
         return None


### PR DESCRIPTION
* copied python_string and when typing  into the editor, a hash pops up

* wip

* change comments to use statements instead of expressions

* add in an if branch for comments within generateAstStatement

* dynamic suggestions for comments work now